### PR TITLE
Resolve Mac compatibility issues

### DIFF
--- a/init
+++ b/init
@@ -14,8 +14,20 @@
 # benefit of this approach is that the implementation of such scripts will
 # automatically track any changes.
 
+# Note that the implementation intentionally avoids using some common regex
+# operators (in particular, '|', '+', and '?'), because the 'find' command
+# differs between operating systems both in its default regex dialect (GNU
+# Emacs for Ubuntu/WSL and BRE for Mac) and in the syntax used to switch
+# dialects, and this init script should be portable across operating systems.
+# See https://www.greenend.org.uk/rjk/tech/regexp.html for an explanation of
+# the differences between regex dialects.
+
 cat <<- 'EOF' > ~/.zshrc
-	
+
 	# Source all .sh and .zsh files within .zshrc.d; see ~/.zshrc.d/init.
-	for FILE in $(find -L ~/.zshrc.d -regex "^.*/.+[.]z?sh$"); do source $FILE; done
+	for FILE in $(find -L ~/.zshrc.d \
+	    -regex '^.*/..*[.]zsh$' \
+	    -or -regex '^.*/..*[.]zsh$')
+	  do source $FILE
+	done
 EOF

--- a/prompt.zsh
+++ b/prompt.zsh
@@ -15,7 +15,7 @@ function git-branch() {
   # From https://gist.github.com/joseluisq/1e96c54fa4e1e5647940
 DOCSTRING
 
-  git branch 2> /dev/null | sed --silent --expression='s/^\* \(.*\)/\1/p'
+  git branch 2> /dev/null | sed -ne 's/^\* \(.*\)/\1/p'
 }
 
 function git-repo() {
@@ -64,4 +64,4 @@ DOCSTRING
 
 setopt PROMPT_SUBST
 export PROMPT="%B%F{green}%3~\$(_git-info-for-prompt)%F{green} %#%f%b "
-export RPROMPT="\$(date --utc '+%T')"
+export RPROMPT="\$(date -u '+%T')"


### PR DESCRIPTION
While setting ZSH up on a new machine (a Mac), I discovered some compatibility issues related to differing syntax in the standard versions of some standard commands (e.g., `find`).  Resolve those issues in such a way that they will work in both Mac and WSL environments.